### PR TITLE
Organize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,14 +276,6 @@ Malo is ultra small css library for building web sites. It is meant to be struct
 
 **Website:** http://code.google.com/p/malo/
 
-## Pure
-
-> A set of small, responsive CSS modules that you can use in every web project.
-
-**Responsive:** Yes
-
-**Website:** http://purecss.io/
-
 ## PureCSS
 
 > A set of small, responsive CSS modules that you can use in every web project, built by the YUI team at Yahoo!.


### PR DESCRIPTION
Because the README list wasn't organized at all, it was getting pretty messy.  The PureCSS framework was included twice within the list, most likely resulting from the general disarray.  I removed the less informative occurrence of the two.
