### PR TITLE
Updating Kickoff’s documentation links in the comparison list and adding it to the index list of frameworks

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -321,6 +321,46 @@
                 </div>
                 <div class="parent">
                     <ul>
+                         <li><h1>Kickoff</h1></li>
+                         <li>
+                             <div class="details">
+                                 <div class="browsers">
+                                    <span class="ie" data-version="8"></span>
+                                   <span class="cr" data-version="+"></span>
+                                   <span class="sa" data-version="+"></span>
+                                   <span class="ff" data-version="+"></span>
+                                   <span class="op" data-version="+"></span>
+                                </div>
+                                <div class="ui">
+                                    <span class="less">LESS</span>
+                                    <span class="sass" data-active="yes">SASS</span>
+                                </div>
+                                <span class="responsive">
+                                    <span class="desktop" data-responsive="yes"></span>
+                                    <span class="mobile" data-responsive="yes"></span>
+                                    <span class="tablet" data-responsive="yes"></span>
+                                </span>
+                            </div>
+                        </li>
+                        <li><h3>MIT</h3></li>
+                    </ul>
+                    <div class="info">
+                        <article>
+                            <blockquote><i></i> A lightweight front-end framework for creating scalable, responsive sites </blockquote>
+                            <p>
+                               Kickoff is an actively maintained front-end framework, created by Zander Martineau and Ashley Nolan.
+                           <br><br>
+                                The framework is not meant to be too prescriptive - we don't want to force developers into a certain coding style - and so can be used as a starting point for any type of project.
+                            </p>
+                        </article>
+                        <aside>
+                            <a target="_blank" href="http://trykickoff.github.io/">Site</a>
+                            <a target="_blank" href="https://github.com/trykickoff/kickoff">Github</a>
+                        </aside>
+                    </div>
+                </div>
+                <div class="parent">
+                    <ul>
                         <li><h1>Kube</h1></li>
                         <li>
                             <div class="details">
@@ -1524,44 +1564,6 @@
                         </aside>
                     </div>
                 </div>
-                                <div class="parent">
-                    <ul>
-                         <li><h1>Kickoff</h1></li>
-                         <li>
-                             <div class="details">
-                                 <div class="browsers">
-                                    <span class="ie" data-version="8"></span>
-                                   <span class="cr" data-version="+"></span>
-                                   <span class="sa" data-version="+"></span>                                   <span class="ff" data-version="+"></span>                                    <span class="op" data-version="+"></span>
-                                </div>
-                                <div class="ui">
-                                    <span class="less">LESS</span>
-                                    <span class="sass" data-active="yes">SASS</span>
-                                </div>
-                                <span class="responsive">
-                                    <span class="desktop" data-responsive="yes"></span>
-                                    <span class="mobile" data-responsive="yes"></span>
-                                    <span class="tablet" data-responsive="yes"></span>
-                                </span>
-                            </div>
-                        </li>
-                        <li><h3>MIT</h3></li>
-                    </ul>
-                    <div class="info">
-                        <article>
-                            <blockquote><i></i> A lightweight front-end framework for creating scalable, responsive sites </blockquote>
-                            <p>
-                               Kickoff is an actively maintained front-end framework, created by Zander Martineau and Ashley Nolan.
-                           <br><br>
-                                The framework is not meant to be too prescriptive - we don't want to force developers into a certain coding style - and so can be used as a starting point for any type of project.
-                            </p>
-                        </article>
-                        <aside>
-                            <a target="_blank" href="http://tmwagency.github.io/kickoff/">Site</a>
-                            <a target="_blank" href="https://github.com/tmwagency/kickoff">Github</a>
-                        </aside>
-                    </div>
-                </div>
                 <div class="parent">
                 <ul>
                     <li><h1>Cascade Framework</h1></li>
@@ -1832,7 +1834,7 @@
                     </aside>
                 </div>
             </div>
-            
+
             <div class="parent">
                 <ul>
                     <li><h1>Topcoat</h1></li>

--- a/index.html
+++ b/index.html
@@ -140,6 +140,20 @@
 
       <p><strong>Website:</strong> <a href="http://www.99lime.com/">http://www.99lime.com/</a></p>
 
+      <h2>Kickoff</h2>
+
+      <blockquote>
+        <p>A lightweight front-end framework for creating scalable, responsive sites.</p>
+      </blockquote>
+
+      <p>Kickoff is an actively maintained front-end framework, created by Zander Martineau and Ashley Nolan.</p>
+
+      <p>The framework is not meant to be too prescriptive - we don't want to force developers into a certain coding style - and so can be used as a starting point for any type of project.</p>
+
+      <p><strong>Responsive:</strong> Yes  </p>
+
+      <p><strong>Website:</strong> <a href="http://trykickoff.github.io/">http://trykickoff.github.io/</a></p>
+
       <h2>Kube</h2>
 
       <blockquote>


### PR DESCRIPTION
Kickoff recently switched it’s repo to a separate organisation TryKickoff.  Have updated the links in the comparison list and added the details for the framework to the basic index list.
